### PR TITLE
Driver/QDac_channels

### DIFF
--- a/docs/examples/driver_examples/Qcodes example with QDac_channels.ipynb
+++ b/docs/examples/driver_examples/Qcodes example with QDac_channels.ipynb
@@ -24,7 +24,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Connect to the instrument\n",
@@ -121,7 +123,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# now setting channel 1 and 2 voltages will cause slow ramps to happen\n",
@@ -144,7 +148,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# To each channel one may assign a sync channel:\n",
@@ -168,7 +174,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# syncs are unassigned by assigning sync 0\n",

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -126,8 +126,6 @@ class QDacMultiChannelParameter(MultiChannelInstrumentParameter):
             qdac._get_status(readcurrents=False)
             output = tuple(chan.parameters[self._param_name].get_latest()
                            for chan in self._channels)
-
-            # call _instrument.get_status() once and then get_latest
         else:
             output = tuple(chan.parameters[self._param_name].get()
                            for chan in self._channels)


### PR DESCRIPTION
Add a channelised QDac Driver

Changes proposed in this pull request:
- Add a driver for a channelised QDac
- Make ChannelList take default MultiChannelInstrumentParameter subclasses as input

<del> Still missing: </del>
 - An example notebook


@jenshnielsen 
