### PR TITLE
fix: allocated_buffers and set_base_setpoints

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/acq_controllers/ATS9360Controller.py
+++ b/qcodes/instrument_drivers/AlazarTech/acq_controllers/ATS9360Controller.py
@@ -189,7 +189,7 @@ class ATS9360Controller(AcquisitionController):
             self.allocated_buffers._save_val(1)
         else:
             self.buffers_per_acquisition._save_val(value)
-            self.allocated_buffers._save_val(value)
+            self.allocated_buffers._save_val(2)
 
     def _int_delay_default(self):
         """

--- a/qcodes/instrument_drivers/AlazarTech/acquisition_parameters.py
+++ b/qcodes/instrument_drivers/AlazarTech/acquisition_parameters.py
@@ -265,15 +265,15 @@ class ExpandingAlazarArrayMultiParameter(MultiParameter):
 
     def set_base_setpoints(self, base_name=None, base_label=None, base_unit=None,
                            setpoints_start=None, setpoints_stop=None):
-        if base_name:
+        if base_name is not None:
             self.setpoint_names_base = (base_name,)
-        if base_label:
+        if base_label is not None:
             self.setpoint_labels_base = (base_label,)
-        if base_unit:
+        if base_unit is not None:
             self.setpoint_units_base = (base_unit,)
-        if setpoints_start:
+        if setpoints_start is not None:
             self.setpoints_start = setpoints_start
-        if setpoints_stop:
+        if setpoints_stop is not None:
             self.setpoints_stop = setpoints_stop
         self.set_setpoints_and_labels()
 


### PR DESCRIPTION
This fixes the number of allocated buffers such that only 2 buffers are allocated even if there are more than 2 buffers per acquisition (because it switches between which buffer takes the data while the other 'offloads' and does not need more than this even if many buffers are taken). It also fixes the set_base_setpoints such that it does not break if you set values to 0 (and rather just checks if they are None or not)

@jenshnielsen 
